### PR TITLE
fix: IFlipSetting

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ export default {
             file: 'build/index.js',
             format: 'cjs',
             sourcemap: true,
+            exports: 'auto',
         },
         {
             file: 'build/index.es.js',

--- a/src/html-flip-book/settings.ts
+++ b/src/html-flip-book/settings.ts
@@ -3,50 +3,50 @@ export type PageOrientation = 'portrait' | 'landscape';
 
 export interface IFlipSetting {
     /** Page number from which to start viewing */
-    startPage: number;
+    startPage?: number;
     /** Whether the book will be stretched under the parent element or not */
-    size: 'fixed' | 'stretch';
+    size?: 'fixed' | 'stretch';
 
     width: number;
     height: number;
 
-    minWidth: number;
-    maxWidth: number;
-    minHeight: number;
-    maxHeight: number;
+    minWidth?: number;
+    maxWidth?: number;
+    minHeight?: number;
+    maxHeight?: number;
 
     /** Draw shadows or not when page flipping */
-    drawShadow: boolean;
+    drawShadow?: boolean;
     /** Flipping animation time */
-    flippingTime: number;
+    flippingTime?: number;
 
     /** Enable switching to portrait mode */
-    usePortrait: boolean;
+    usePortrait?: boolean;
     /** Initial value to z-index */
-    startZIndex: number;
+    startZIndex?: number;
     /** If this value is true, the parent element will be equal to the size of the book */
-    autoSize: boolean;
+    autoSize?: boolean;
     /** Shadow intensity (1: max intensity, 0: hidden shadows) */
-    maxShadowOpacity: number;
+    maxShadowOpacity?: number;
 
     /** If this value is true, the first and the last pages will be marked as hard and will be shown in single page mode */
-    showCover: boolean;
+    showCover?: boolean;
     /** Disable content scrolling when touching a book on mobile devices */
-    mobileScrollSupport: boolean;
+    mobileScrollSupport?: boolean;
 
     /** Set the forward event of clicking on child elements (buttons, links) */
-    clickEventForward: boolean;
+    clickEventForward?: boolean;
 
     /** Using mouse and touch events to page flipping */
-    useMouseEvents: boolean;
+    useMouseEvents?: boolean;
 
-    swipeDistance: number;
+    swipeDistance?: number;
 
     /** if this value is true, fold the corners of the book when the mouse pointer is over them. */
-    showPageCorners: boolean;
+    showPageCorners?: boolean;
 
     /** if this value is true, flipping by clicking on the whole book will be locked. Only on corners */
-    disableFlipByClick: boolean;
+    disableFlipByClick?: boolean;
 }
 
 export interface IBookState {
@@ -55,9 +55,9 @@ export interface IBookState {
 }
 
 export interface IEventProps {
-    onFlip?: (flipEvent: any) => void;
-    onChangeOrientation?: (flipEvent: any) => void;
-    onChangeState?: (flipEvent: any) => void;
-    onInit?: (flipEvent: any) => void;
-    onUpdate?: (flipEvent: any) => void;
-}
+    onFlip?: (flipEvent: unknown) => void;
+    onChangeOrientation?: (flipEvent: unknown) => void;
+    onChangeState?: (flipEvent: unknown) => void;
+    onInit?: (flipEvent: unknown) => void;
+    onUpdate?: (flipEvent: unknown) => void;
+  }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { HTMLFlipBook } from './html-flip-book';
 
 export default HTMLFlipBook;


### PR DESCRIPTION
I have fixed the interface of IFlipSetting and IEventProps so that accessories are no longer mandatory, except for height and width.